### PR TITLE
Add a new mix task: `make_admin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@
 /db
 /deps
 /*.ez
-.idea
+/.idea
+/.elixir_ls
 
 # Generated on crash by the VM
 erl_crash.dump

--- a/lib/mix/tasks/make_admin.ex
+++ b/lib/mix/tasks/make_admin.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.MakeAdmin do
+  @moduledoc """
+  Makes the specified users an admin. The user must already exist in
+  the system, ie. they must have logged in at least once before running
+  this mix task.
+
+  ## Usage
+
+      mix make_admin user@example.com
+  """
+
+  use Mix.Task
+
+  def run([email]) do
+    Mix.EctoSQL.ensure_started(LibTen.Repo, [])
+
+    LibTen.Accounts.get_by!(%{email: String.downcase(email)})
+    |> LibTen.Accounts.Users.update(%{is_admin: true})
+
+    Mix.shell().info("Made #{email} an admin")
+  end
+
+  def run([]) do
+    Mix.shell().error("Please provide an email as an argument")
+  end
+
+  def run(_args) do
+    Mix.shell().error("Please provide an email as the only argument")
+  end
+end


### PR DESCRIPTION
Mark user as admin using a mix task, so that we don't need to fiddle with the database manually